### PR TITLE
React.PropTypes.

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -48,6 +48,10 @@
     prefix: "_pt"
     body: "propTypes: {\n\t${1}: React.PropTypes.${2:string}\n},"
 
+  "React: React.PropTypes.":
+      prefix: "_rpt"
+      body: "React.PropTypes."
+
   "React: component skeleton":
     prefix: "_rcc"
     body: "'use strict';\nimport React from 'react';\n\nexport default React.createClass({\n\n\trender() {\n\t\treturn (\n\t\t\t${1:<div />}\n\t\t);\n\t}\n\n});"


### PR DESCRIPTION
`React.PropTypes.` is used frequently in `propTypes`.
It's worth to have its own snippet.
