### PR TITLE
add stateless function snippet

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -63,9 +63,17 @@
     prefix: "_rcc"
     body: "'use strict';\nimport React from 'react';\n\nexport default React.createClass({\n\n\trender() {\n\t\treturn (\n\t\t\t${1:<div />}\n\t\t);\n\t}\n\n});"
 
+  "React: Stateless Component":
+    prefix: "_rsc"
+    body: "'use strict';\nimport React from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+
   "React: Stateless Function":
     prefix: "_rsf"
-    body: "'use strict';\nimport React from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.displayName = '${1}';\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+    body: "const ${1} = ({${2}}) => (\n\t<div>{${2}}</div>\n);"
+
+  "React: Component displayName":
+    prefix: "_cdn"
+    body: "${1}.displayName = '${1}';"
 
   "React: render() { return ... }":
     prefix: "_ren"

--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -63,6 +63,10 @@
     prefix: "_rcc"
     body: "'use strict';\nimport React from 'react';\n\nexport default React.createClass({\n\n\trender() {\n\t\treturn (\n\t\t\t${1:<div />}\n\t\t);\n\t}\n\n});"
 
+  "React: Stateless Function":
+    prefix: "_rsf"
+    body: "'use strict';\nimport React from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.displayName = '${1}';\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+
   "React: render() { return ... }":
     prefix: "_ren"
     body: "render() {\n\treturn (\n\t\t${1:<div />}\n\t);\n}"


### PR DESCRIPTION
Added a new `stateless function snippet` that I've been using quite a bit lately and thought it would be helpful to introduce to others as well.

`_rsf` is short for React stateless function

Let me know what you think of the format. It's based on https://facebook.github.io/react/docs/reusable-components.html#stateless-functions

``` javascript
'use strict';
import React from 'react';

const Cat = ({name}) => (
    <div>{name}</div>
);

Cat.displayName = 'Cat';
Cat.propTypes = {
    name: React.PropTypes.String
};

export default Cat;
```
