### PR TITLE
Remove 'use strict'; from snippets

### DIFF
--- a/snippets/Flux.cson
+++ b/snippets/Flux.cson
@@ -1,12 +1,12 @@
 ".source.js":
   "Flux Action":
     prefix: "_fa"
-    body: "'use strict';\nimport ${1:AppDispatcher} from '../dispatcher/${1:AppDispatcher}';\nimport ${2:constants} from '../constants/${2:constants}';\nimport ${3:utils} from '../utils/${3:utils};'\n\nexport default {\n\t${4}\n};"
+    body: "import ${1:AppDispatcher} from '../dispatcher/${1:AppDispatcher}';\nimport ${2:constants} from '../constants/${2:constants}';\nimport ${3:utils} from '../utils/${3:utils};'\n\nexport default {\n\t${4}\n};"
 
   "Flux: AppDispatcher":
     prefix: "_fad"
-    body: "'use strict';\nimport { Dispatcher } from 'flux';\n\nlet AppDispatcher = new Dispatcher();\n\nAppDispatcher.handleAction = function(action) {\n\tthis.dispatch({\n\t\tsource: 'VIEW_ACTION',\n\t\taction: action\n\t});};\n\nexport default AppDispatcher;"
+    body: "import { Dispatcher } from 'flux';\n\nlet AppDispatcher = new Dispatcher();\n\nAppDispatcher.handleAction = function(action) {\n\tthis.dispatch({\n\t\tsource: 'VIEW_ACTION',\n\t\taction: action\n\t});};\n\nexport default AppDispatcher;"
 
   "Flux: Store":
     prefix: "_fs"
-    body: "'use strict';\nimport ${1:AppDispatcher} from '../dispatcher/${1:AppDispatcher}';\nimport ${2:appConstants} from '../constants/${2:appConstants}';\nimport { EventEmitter } from 'event';\nimport assign from 'react/lib/Object.assign';\n\nlet _state = {};\n\nlet ${3:store} = assign({}, EventEmitter.prototype, {\n\t${4}\n});\n\nAppDispatcher.register((payload) => {\n\tlet { action } = payload;\n\n\t switch(action.actionType) {\n\n\t\tdefault:\n\t\t\treturn true;\n\t}\n});\n\nexport default ${3:store};"
+    body: "import ${1:AppDispatcher} from '../dispatcher/${1:AppDispatcher}';\nimport ${2:appConstants} from '../constants/${2:appConstants}';\nimport { EventEmitter } from 'event';\nimport assign from 'react/lib/Object.assign';\n\nlet _state = {};\n\nlet ${3:store} = assign({}, EventEmitter.prototype, {\n\t${4}\n});\n\nAppDispatcher.register((payload) => {\n\tlet { action } = payload;\n\n\t switch(action.actionType) {\n\n\t\tdefault:\n\t\t\treturn true;\n\t}\n});\n\nexport default ${3:store};"

--- a/snippets/React Router.cson
+++ b/snippets/React Router.cson
@@ -2,7 +2,6 @@
   'Router: router skeleton':
     'prefix': '_rr'
     'body': """
-      'use strict';
       import React from 'react';
       import ReactDOM from 'react-dom';
       import Router from 'react-router';


### PR DESCRIPTION
Remove `'use strict';` from snippets as discussed in #23
