### PR TITLE
Add react stateless component click and react stateless component return snippet

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -103,6 +103,14 @@
     prefix: "_rsc"
     body: "import React from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
 
+  "React: Stateless Component Return":
+    prefix: "_rscr"
+    body: "import React from 'react';\n\nconst ${1} = ({${2}}) => {\n\treturn (\n\t\t<div>${4}</div>\n\t);\n}\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+
+  "React: Stateless Component Click":
+    prefix: "_rscc"
+    body: "import React from 'react';\n\nconst ${1} = ({${2}}) => {\n\tconst handleClick = () => {};\n\treturn (\n\t\t<div onClick={handleClick}>${4}</div>\n\t);\n}\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+
   "React: Stateless Component PropTypes":
     prefix: "_rscp"
     body: "import React, {PropTypes} from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.propTypes = {\n\t${2}: PropTypes.${3}\n};\n\nexport default ${1};"


### PR DESCRIPTION
Added the original stateless function with click handler we talked about, fixes #38.

I also ended up adding one more snippet, which is a simple stateless component with a return statement, that allows for further customizing but doesn't force the user to add an onClick handler.

Which looks like this:

```jsx
const ${1} = ({${2}}) => {
    return (
        <div>${4}</div>
    );
}

${1}.propTypes = {
    ${2}: React.PropTypes.${3}
};

export default ${1};
``` 

