### PR TITLE
Update React (JSX).cson

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -61,11 +61,11 @@
 
   "React: Class.contextTypes = { ... }":
     prefix: "_cct"
-    body: "${1}.contextTypes = {\n\t${2}: React.PropTypes.${3:string}\n};"
+    body: "${1}.contextTypes = {\n\t${2}: PropTypes.${3:string}\n};"
 
   "React: Class.propTypes = { ... }":
     prefix: "_cpt"
-    body: "${1}.propTypes = {\n\t${2}: React.PropTypes.${3:string}\n};"
+    body: "${1}.propTypes = {\n\t${2}: PropTypes.${3:string}\n};"
 
   "React: Class.defaultProps = { ... }":
     prefix: "_cdp"
@@ -85,11 +85,7 @@
 
   "React: propTypes { ... }":
     prefix: "_pt"
-    body: "propTypes: {\n\t${1}: React.PropTypes.${2:string}\n},"
-
-  "React: React.PropTypes.":
-      prefix: "_rpt"
-      body: "React.PropTypes."
+    body: "propTypes: {\n\t${1}: PropTypes.${2:string}\n},"
 
   "React: class skeleton":
     prefix: "_cer"
@@ -101,15 +97,15 @@
 
   "React: Stateless Component":
     prefix: "_rsc"
-    body: "import React from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+    body: "import React from 'react';\nimport PropTypes from 'prop-types';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\n${1}.propTypes = {\n\t${2}: PropTypes.${3}\n};\n\nexport default ${1};"
 
   "React: Stateless Component Return":
     prefix: "_rscr"
-    body: "import React from 'react';\n\nconst ${1} = ({${2}}) => {\n\treturn (\n\t\t<div>${4}</div>\n\t);\n}\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+    body: "import React from 'react';\nimport PropTypes from 'prop-types';\n\nconst ${1} = ({${2}}) => {\n\treturn (\n\t\t<div>${4}</div>\n\t);\n}\n\n${1}.propTypes = {\n\t${2}: PropTypes.${3}\n};\n\nexport default ${1};"
 
   "React: Stateless Component Click":
     prefix: "_rscc"
-    body: "import React from 'react';\n\nconst ${1} = ({${2}}) => {\n\tconst handleClick = () => {};\n\treturn (\n\t\t<div onClick={handleClick}>${4}</div>\n\t);\n}\n\n${1}.propTypes = {\n\t${2}: React.PropTypes.${3}\n};\n\nexport default ${1};"
+    body: "import React from 'react';\nimport PropTypes from 'prop-types';\n\nconst ${1} = ({${2}}) => {\n\tconst handleClick = () => {};\n\treturn (\n\t\t<div onClick={handleClick}>${4}</div>\n\t);\n}\n\n${1}.propTypes = {\n\t${2}: PropTypes.${3}\n};\n\nexport default ${1};"
 
   "React: Stateless Component PropTypes":
     prefix: "_rscp"


### PR DESCRIPTION
- Fix missing 'prop-types' package import
- Remove useless snippet `_rpt` which does `React.PropTypes.`
- N.B.: `_rsc` and `_rscp` are the same. Maybe we could remove `_rscp`?