### PR TITLE
Add snippet for import React, { Component } from react;

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -7,6 +7,10 @@
     prefix: "_ir"
     body: "import React from 'react';"
 
+  "React: import() with Component":
+    prefix: "_irc"
+    body: "import React, { Component } from 'react';"
+
   "React: import() with PropTypes":
     prefix: "_irp"
     body: "import React from 'react';\nimport PropTypes from 'prop-types';"


### PR DESCRIPTION
Introduces a new snippet:

`_irc` 

Which renders:

`import React, { Component } from 'react';`

Just thought this might be a handy one as I'm constantly typing this out! Thanks AJ! 