### PR TITLE
Add snippet for export & export default: _ex & _exd respectively

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -15,6 +15,14 @@
     prefix: "_ird"
     body: "import ReactDOM from 'react-dom';"
 
+  "React: export empty()":
+    prefix: "_ex"
+    body: "export ${1};"
+  
+  "React: export default empty()":
+    prefix: "_exd"
+    body: "export default ${1};"
+
   "React: componentDidMount() { ... }":
     prefix: "_cdm"
     body: "componentDidMount() {\n\t${1}\n}${2}"

--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -18,7 +18,7 @@
   "React: export empty()":
     prefix: "_ex"
     body: "export ${1};"
-  
+
   "React: export default empty()":
     prefix: "_exd"
     body: "export default ${1};"


### PR DESCRIPTION
Introduces two new snippets:

`_ex`

For: 

`export ${1}`

and:

`_exd`

For: 

`export default ${1}`

  

> I thought these also may be useful! =] 