### PR TITLE
Add componentDidCatch from React 16

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -33,7 +33,7 @@
 
   "React: componentDidCatch(error, info) { ... }":
     prefix: "_cdc"
-    body: "componentDidUpdate(error, info) {\n\t${1}\n}${2}"
+    body: "componentDidCatch(error, info) {\n\t${1}\n}${2}"
 
   "React: componentDidUpdate(pp, ps) { ... }":
     prefix: "_cdup"

--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -31,6 +31,10 @@
     prefix: "_cdm"
     body: "componentDidMount() {\n\t${1}\n}${2}"
 
+  "React: componentDidCatch(error, info) { ... }":
+    prefix: "_cdc"
+    body: "componentDidUpdate(error, info) {\n\t${1}\n}${2}"
+
   "React: componentDidUpdate(pp, ps) { ... }":
     prefix: "_cdup"
     body: "componentDidUpdate(prevProps, prevState) {\n\t${1}\n}${2}"


### PR DESCRIPTION
Should add componentDidCatch snippet as _cdc to help with taking advantage of this part of React 16.