### PR TITLE
Added PureComponent import prefix and corrected title of _ircp prefix

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -11,11 +11,15 @@
     prefix: "_irc"
     body: "import React, { Component } from 'react';"
 
+  "React: import with PureComponent":
+    prefix: "_irpc"
+    body: "import React, { PureComponent } from 'react';"
+
   "React: import with PropTypes":
     prefix: "_irp"
     body: "import React from 'react';\nimport PropTypes from 'prop-types';"
 
-  "React: import with Component":
+  "React: import with Component and PropTypes":
     prefix: "_ircp"
     body: "import React, { Component } from 'react';\nimport PropTypes from 'prop-types';"
 


### PR DESCRIPTION
Since I'm using PureComponent from now and then I added a new prefix _irpc (import react with PureCompoenent"

Additionally I found a small bug: _irc and _ircp had the same title, so _irc didn't work. 