### PR TITLE
Update React (JSX).cson

### DIFF
--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -3,6 +3,10 @@
     prefix: "_i"
     body: "import ${1} from '${2}';"
 
+  "React: import empty named":
+    prefix: "_in"
+    body: "import { ${1} } from '${2}';"
+
   "React: import":
     prefix: "_ir"
     body: "import React from 'react';"
@@ -103,6 +107,10 @@
     prefix: "_cer"
     body: "import React, { Component } from 'react';\n\nclass ${1} extends Component {\n\n\trender() {\n\t\treturn (\n\t\t\t${2:<div></div>}\n\t\t);\n\t}\n\n}\n\nexport default ${1};"
 
+  "React: pure class skeleton":
+    prefix: "_cepr"
+    body: "import React, { PureComponent } from 'react';\n\nclass ${1} extends PureComponent {\n\n\trender() {\n\t\treturn (\n\t\t\t${2:<div></div>}\n\t\t);\n\t}\n\n}\n\nexport default ${1};"
+
   "React: Stateless Component":
     prefix: "_rsc"
     body: "import React from 'react';\n\nconst ${1} = ({${2}}) => (\n\t<div>${4}</div>\n);\n\nexport default ${1};"
@@ -139,9 +147,21 @@
     prefix: "_props"
     body: "this.props.${1}"
 
+  "React: destruct this.props.":
+    prefix: "_dprops"
+    body: "const { ${1} } = this.props;"
+
   "React: this.state.":
     prefix: "_state"
     body: "this.state.${1}"
+
+  "React: destruct this.state.":
+    prefix: "_dstate"
+    body: "const { ${1} } = this.state;"
+
+  "React: destruct object.":
+    prefix: "_dobj"
+    body: "const { ${1} } = ${2};"
 
   "React: render(component, container, [callback])":
     prefix: "_rrc"


### PR DESCRIPTION
Added additional snippets:

- [x] import named module
- [x] class skeleton for React.PureComponent
- [x] destruct this.props
- [x] destruct this.state
- [x] destruct generic object

Tried to follow naming schema but open for changes. 

I could also add some snippets for [Redux](https://github.com/reactjs/react-redux) / [Recompose](https://github.com/acdlite/recompose) / [Reselect](https://github.com/reactjs/reselect) which i guess are used regularly with react. But after all, its called react-snippets, so maybe this should go into its own package