### PR TITLE
add import prop-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The **⇥** means the `TAB` key
 | `_ir→`      | import react |
 | `_irc→`     | import react and component |
 | `_irp→`     | import react and prop-types |
+| `_ipt→`     | import prop-types |
 | `_ircp→`    | import react, component and prop-types |
 | `_ird→`     | import react-dom |
 | `_ex→`      | export |

--- a/snippets/React (JSX).cson
+++ b/snippets/React (JSX).cson
@@ -23,6 +23,10 @@
     prefix: "_irp"
     body: "import React from 'react';\nimport PropTypes from 'prop-types';"
 
+  "React: import PropTypes":
+    prefix: "_ipt"
+    body: "import PropTypes from 'prop-types';"
+
   "React: import with Component and PropTypes":
     prefix: "_ircp"
     body: "import React, { Component } from 'react';\nimport PropTypes from 'prop-types';"


### PR DESCRIPTION
Adds import of `prop-types` without importing `react`.

Can be useful if prop-types need to be imported after importing React and creating a component.